### PR TITLE
fix: order of create docker img

### DIFF
--- a/.github/workflows/docker-cosmoscan.yml
+++ b/.github/workflows/docker-cosmoscan.yml
@@ -24,5 +24,5 @@ jobs:
           file: ./projects/cosmoscan/Dockerfile
           push: true
           tags: |
-            lcnem/cosmoscan:latest
             lcnem/cosmoscan:${{ steps.variables.outputs.version }}
+            lcnem/cosmoscan:latest


### PR DESCRIPTION
close #42 

docker img作成の順番を変更。

@YasunoriMATSUOKA 確認お願いします。botanyにも同様の変更ありです。
https://github.com/lcnem/botany/pull/48