### PR TITLE
feat: annual provisions in top page

### DIFF
--- a/projects/cosmoscan/src/app/home/mint/mint.component.html
+++ b/projects/cosmoscan/src/app/home/mint/mint.component.html
@@ -1,1 +1,1 @@
-<view-mint [inflation]="inflation$ | async"></view-mint>
+<view-mint [inflation]="inflation$ | async" [annualProvisions]="annualProvisions$ | async"></view-mint>

--- a/projects/cosmoscan/src/app/home/mint/mint.component.ts
+++ b/projects/cosmoscan/src/app/home/mint/mint.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { rest } from 'cosmos-client';
-import { CosmosMintV1beta1QueryInflationResponse } from 'cosmos-client/cjs/openapi/api';
+import { CosmosMintV1beta1QueryAnnualProvisionsResponse, CosmosMintV1beta1QueryInflationResponse } from 'cosmos-client/cjs/openapi/api';
 import { CosmosSDKService } from 'projects/cosmoscan/src/model/cosmos-sdk.service';
-import { combineLatest, Observable, timer } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-mint',
@@ -13,18 +13,17 @@ import { map, mergeMap } from 'rxjs/operators';
 })
 export class MintComponent implements OnInit {
   inflation$: Observable<CosmosMintV1beta1QueryInflationResponse>;
+  annualProvisions$: Observable<CosmosMintV1beta1QueryAnnualProvisionsResponse>;
 
   constructor(private readonly route: ActivatedRoute, private readonly cosmosSDK: CosmosSDKService) {
-    const timer$ = timer(0, 60 * 1000);
-    const combined$ = combineLatest([timer$, this.cosmosSDK.sdk$]).pipe(map(([_, sdk]) => sdk));
-    this.inflation$ = combined$.pipe(
+    this.inflation$ = this.cosmosSDK.sdk$.pipe(
       mergeMap((sdk) => rest.cosmos.mint.inflation(sdk.rest).then((res) => res.data)
+    ));
+    this.annualProvisions$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) => rest.cosmos.mint.annualProvisions(sdk.rest).then((res) => res.data)
     ));
    }
 
   ngOnInit(): void {
-  //一時的にデバッグ用に追加
-  console.log('inflation');
-  console.log(this.inflation$);
   }
 }

--- a/projects/cosmoscan/src/view/home/mint/mint.component.html
+++ b/projects/cosmoscan/src/view/home/mint/mint.component.html
@@ -8,3 +8,14 @@
     </mat-list-item>
   </mat-list>
 </mat-card>
+
+<h2>Annual Provisions</h2>
+<mat-card>
+  <mat-list>
+    <mat-list-item>
+      <span class="column-name">Current Annual Expected Provisions: </span>
+      <span fxFlex="auto"></span>
+      <span class="column-value">{{ annualProvisions?.annual_provisions }}</span>
+    </mat-list-item>
+  </mat-list>
+</mat-card>

--- a/projects/cosmoscan/src/view/home/mint/mint.component.ts
+++ b/projects/cosmoscan/src/view/home/mint/mint.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { CosmosMintV1beta1QueryInflationResponse } from 'cosmos-client/cjs/openapi/api';
+import { CosmosMintV1beta1QueryAnnualProvisionsResponse, CosmosMintV1beta1QueryInflationResponse } from 'cosmos-client/cjs/openapi/api';
 
 @Component({
   selector: 'view-mint',
@@ -9,6 +9,8 @@ import { CosmosMintV1beta1QueryInflationResponse } from 'cosmos-client/cjs/opena
 export class MintComponent implements OnInit {
   @Input()
   inflation?: CosmosMintV1beta1QueryInflationResponse | null;
+  @Input()
+  annualProvisions?: CosmosMintV1beta1QueryAnnualProvisionsResponse | null;
 
   constructor() { }
 


### PR DESCRIPTION
`annual provisions` 現在での予想年間供給のインフレ率
![annualprovisions](https://user-images.githubusercontent.com/29295263/130206247-747defaf-7021-4563-a939-6ff834f25a56.PNG)

`Inflation`と同じくJPYX-1-testでの動作は現時点では不可能なのでtestchainで動作させています。

@KimuraYu45z @YasunoriMATSUOKA 
`latest-blocks-txs-initial`ブレンチとは無関係の修正です。
レビューお願いします。