### PR TITLE
Validator sets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6825,9 +6825,9 @@
       }
     },
     "cosmos-client": {
-      "version": "0.42.13",
-      "resolved": "https://registry.npmjs.org/cosmos-client/-/cosmos-client-0.42.13.tgz",
-      "integrity": "sha512-EIcD7ulJwkcT/fa3Mbut5U+TUpn3yunCd2TUQQKqBXJnQ0lsAXQ8J15cyprFT5EKs7EuxUuft1tZeIHdIXXCBw==",
+      "version": "0.42.14",
+      "resolved": "https://registry.npmjs.org/cosmos-client/-/cosmos-client-0.42.14.tgz",
+      "integrity": "sha512-vvZu6wh2tOEgiQSrDkFu2D8yA9t1Degpx0pjEjjwIMfXtTR0KOrlNH9lNIPwuQEkjZuJt4OANVySkW/s1e8Y5Q==",
       "requires": {
         "axios": "^0.21.1",
         "bech32": "^1.1.3",
@@ -17721,9 +17721,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.3.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.2.tgz",
-          "integrity": "sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw=="
+          "version": "16.7.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+          "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@ngneat/tailwind": "^7.0.3",
     "@types/bip39": "^3.0.0",
     "bip39": "^3.0.3",
-    "cosmos-client": "^0.42.13",
+    "cosmos-client": "^0.42.14",
     "dexie": "^3.0.2",
     "dotenv": "^8.2.0",
     "ng-loading-dialog": "^12.0.5",

--- a/projects/cosmoscan/src/app/blocks/block/block.component.html
+++ b/projects/cosmoscan/src/app/blocks/block/block.component.html
@@ -1,1 +1,1 @@
-<view-block [block]="block$ | async"></view-block>
+<view-block [block]="block$ | async" [validatorsets]="validatorsets$ | async"></view-block>

--- a/projects/cosmoscan/src/app/blocks/block/block.component.ts
+++ b/projects/cosmoscan/src/app/blocks/block/block.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { rest } from 'cosmos-client';
+import { CosmosBaseTendermintV1beta1GetValidatorSetByHeightResponse } from 'cosmos-client/cjs/openapi/api';
 import { InlineResponse20032 } from 'cosmos-client/esm/openapi';
 import { CosmosSDKService } from 'projects/cosmoscan/src/model/cosmos-sdk.service';
 import { combineLatest, Observable } from 'rxjs';
@@ -14,13 +15,22 @@ import { map, mergeMap } from 'rxjs/operators';
 export class BlockComponent implements OnInit {
   blockHeight$: Observable<string>;
   block$: Observable<InlineResponse20032>;
+  validatorsets$: Observable<CosmosBaseTendermintV1beta1GetValidatorSetByHeightResponse>;
 
   constructor(private route: ActivatedRoute, private cosmosSDK: CosmosSDKService) {
     this.blockHeight$ = this.route.params.pipe(map((params) => params.block_height));
     this.block$ = combineLatest([this.cosmosSDK.sdk$, this.blockHeight$]).pipe(
       mergeMap(([sdk, height]) => rest.cosmos.tendermint.getBlockByHeight(sdk.rest, BigInt(height)).then((res) => res.data)),
     );
+    this.validatorsets$ = combineLatest([this.cosmosSDK.sdk$, this.blockHeight$]).pipe(
+      mergeMap(([sdk, height]) => rest.cosmos.tendermint.getValidatorSetByHeight(sdk.rest, height).then((res) => res.data)),
+    );
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {
+    this.validatorsets$?.subscribe((validatorsets) => {
+      console.log('validatorsets');
+      console.log(validatorsets);
+   });
+  }
 }

--- a/projects/cosmoscan/src/view/blocks/block/block.component.html
+++ b/projects/cosmoscan/src/view/blocks/block/block.component.html
@@ -23,3 +23,29 @@
     <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
+
+<h3>Validatorsets</h3>
+<ng-container *ngFor = "let validatorset of validatorsets?.validators">
+  <mat-card>
+    <mat-list>
+      <mat-list-item>
+        <span class="column-name">Address:</span>
+        <span fxFlex="auto"></span>
+        <span class="column-value">{{ validatorset.address }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+      <mat-list-item>
+        <span class="column-name">Voting Power:</span>
+        <span fxFlex="auto"></span>
+        <span class="column-value">{{ validatorset.voting_power }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+      <mat-list-item>
+        <span class="column-name">Proposer Priority:</span>
+        <span fxFlex="auto"></span>
+        <span class="column-value">{{ validatorset.proposer_priority }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+    </mat-list>
+  </mat-card>
+</ng-container>

--- a/projects/cosmoscan/src/view/blocks/block/block.component.ts
+++ b/projects/cosmoscan/src/view/blocks/block/block.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { CosmosBaseTendermintV1beta1GetValidatorSetByHeightResponse } from 'cosmos-client/cjs/openapi/api';
 import { InlineResponse20032 } from 'cosmos-client/esm/openapi';
 
 @Component({
@@ -9,6 +10,8 @@ import { InlineResponse20032 } from 'cosmos-client/esm/openapi';
 export class BlockComponent implements OnInit {
   @Input()
   block?: InlineResponse20032 | null;
+  @Input()
+  validatorsets?: CosmosBaseTendermintV1beta1GetValidatorSetByHeightResponse | null;
 
   constructor() { }
 


### PR DESCRIPTION
/blocks/{height}
![validatorset](https://user-images.githubusercontent.com/29295263/130408912-9cd376f8-cf2d-495b-a341-c1a5d0739e4c.PNG)

Blockの詳細ページにValidatorset情報の表示を追加。
ValidatorsetsByHeightを有効化するためにcosmos-client-tsのVersionを更新。
