### PR TITLE
fix: delete old txs over 20

### DIFF
--- a/projects/cosmoscan/src/app/home/txs/txs.component.ts
+++ b/projects/cosmoscan/src/app/home/txs/txs.component.ts
@@ -34,7 +34,7 @@ export class TxsComponent implements OnInit {
       /* websocket有効化後、自動削除を有効に
       this.initialTxs$ = combineLatest([initial, ws.asObservable()]).pipe(
         map(([init, latest]) => {
-          (latest as websocket.ResponseSchema).result.data !== undefined ? (init?.pop()) as CosmosTxV1beta1GetTxsEventResponseTxResponses[] : init;
+          (latest as websocket.ResponseSchema).result.data !== undefined ? (init?.shift()) as CosmosTxV1beta1GetTxsEventResponseTxResponses[] : init;
           return init;
         }),
       );


### PR DESCRIPTION
#113 にてHTML側で配列を降順にする変更が入ったため、TS側の配列の処理を変更。
現在はWebsocketがJPYXで使用できていないため、コメントアウト中の箇所になります。

```
      /* websocket有効化後、自動削除を有効に
      this.initialTxs$ = combineLatest([initial, ws.asObservable()]).pipe(
        map(([init, latest]) => {
          (latest as websocket.ResponseSchema).result.data !== undefined ? (init?.shift()) as CosmosTxV1beta1GetTxsEventResponseTxResponses[] : init;
          return init;
        }),
      );
      //*/

```
