### PR TITLE
feat: txs ascending pagination and fix txs and blocks layout

### DIFF
--- a/projects/main/src/app/pages/txs/txs.component.html
+++ b/projects/main/src/app/pages/txs/txs.component.html
@@ -1,5 +1,5 @@
 <view-txs
-  [latestTxs]="latestTxs$ | async"
+  [txs]="txs$ | async"
   [txTypeOptions]="txTypeOptions"
   [selectedTxType]="selectedTxType$ | async"
   [pageSize]="pageSize$ | async"

--- a/projects/main/src/app/pages/txs/txs.component.ts
+++ b/projects/main/src/app/pages/txs/txs.component.ts
@@ -6,7 +6,7 @@ import { CosmosTxV1beta1GetTxsEventResponseTxResponses } from 'cosmos-client/esm
 import { ConfigService } from 'projects/main/src/app/models/config.service';
 import { CosmosSDKService } from 'projects/main/src/app/models/cosmos-sdk.service';
 import { BehaviorSubject, combineLatest, Observable, timer } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { filter, map, mergeMap, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-txs',
@@ -14,17 +14,16 @@ import { map, mergeMap } from 'rxjs/operators';
   styleUrls: ['./txs.component.css'],
 })
 export class TxsComponent implements OnInit {
-  pageSizeOptions = [5, 10, 20];
+  pageSizeOptions = [5, 10, 20, 50, 100];
   pageSize$: BehaviorSubject<number> = new BehaviorSubject(10);
   pageNumber$: BehaviorSubject<number> = new BehaviorSubject(1);
-  pageLength$: BehaviorSubject<number> = new BehaviorSubject(1000);
+  pageLength$: BehaviorSubject<number> = new BehaviorSubject(0);
 
-  latestTxHeight$ = new BehaviorSubject(BigInt(20));
-  firstTxHeight$ = new BehaviorSubject(BigInt(20));
-  num_: bigint | undefined;
+  txsTotalCount$: Observable<bigint>;
+  txsPageOffset$: Observable<bigint>;
 
   pollingInterval = 30;
-  latestTxs$?: Observable<CosmosTxV1beta1GetTxsEventResponseTxResponses[] | undefined>;
+  txs$?: Observable<CosmosTxV1beta1GetTxsEventResponseTxResponses[] | undefined>;
   txTypeOptions?: string[];
   selectedTxType$: BehaviorSubject<string> = new BehaviorSubject('bank');
 
@@ -36,42 +35,65 @@ export class TxsComponent implements OnInit {
     this.txTypeOptions = this.configService.config.extension?.messageModules;
     const timer$ = timer(0, this.pollingInterval * 1000);
     const sdk$ = timer$.pipe(mergeMap((_) => this.cosmosSDK.sdk$));
-    this.latestTxs$ = combineLatest([sdk$, this.selectedTxType$]).pipe(
-      mergeMap(([sdk, selectedTxType]) => {
-        rest.cosmos.tx
-          .getTxsEvent(
-            sdk.rest,
-            [`message.module='${selectedTxType}'`],
-            undefined, // Todo: for pagination
-            undefined, // Todo: for pagination
-            undefined, // Todo: for pagination
-          )
-          .then((res) => {
-            const arr = res.data.tx_responses;
-            if (arr === undefined) {
-            } else {
-              this.num_ = BigInt(arr.length);
-            }
-            console.log('txs_no_number', this.num_);
-            console.log('latestTxHeight$', this.latestTxHeight$.getValue());
-            console.log('pageSize$', this.pageSize$.getValue());
-            console.log('pageNumber$', this.pageNumber$.getValue());
-            console.log('pageLength$', this.pageLength$.getValue());
-          });
-
+    this.txsPageOffset$ = combineLatest([this.pageNumber$, this.pageSize$]).pipe(
+      map(([pageNumber, pageSize]) => {
+        const pageOffset = pageSize * (pageNumber - 1) + 1;
+        return BigInt(pageOffset);
+      }),
+    );
+    this.txsTotalCount$ = combineLatest([
+      sdk$,
+      this.pageSize$,
+      this.txsPageOffset$,
+      this.selectedTxType$,
+    ]).pipe(
+      switchMap(([sdk, _pageSize, _pageOffset, selectedTxType]) => {
         return rest.cosmos.tx
           .getTxsEvent(
             sdk.rest,
             [`message.module='${selectedTxType}'`],
-            undefined, // Todo: for pagination
-            undefined, // Todo: for pagination
-            undefined, // Todo: for pagination
+            undefined,
+            undefined,
+            undefined,
+            true,
+          )
+          .then((res) =>
+            res.data.pagination?.total ? BigInt(res.data.pagination?.total) : BigInt(0),
+          )
+          .catch((error) => {
+            console.error(error);
+            return BigInt(0);
+          });
+      }),
+    );
+    this.txsTotalCount$.subscribe((txsTotalCount) => {
+      this.pageLength$.next(parseInt(txsTotalCount.toString()));
+    });
+    this.txs$ = combineLatest([
+      sdk$,
+      this.selectedTxType$,
+      this.pageSize$.asObservable(),
+      this.txsPageOffset$,
+      this.txsTotalCount$,
+    ]).pipe(
+      filter(
+        ([_sdk, _selectedTxType, _pageSize, _pageOffset, txTotalCount]) =>
+          txTotalCount !== BigInt(0),
+      ),
+      switchMap(([sdk, selectedTxType, pageSize, pageOffset, _txTotalCount]) => {
+        return rest.cosmos.tx
+          .getTxsEvent(
+            sdk.rest,
+            [`message.module='${selectedTxType}'`],
+            undefined,
+            pageOffset,
+            BigInt(pageSize),
+            true,
           )
           .then((res) => {
             return res.data.tx_responses;
           });
       }),
-      map((latestTxs) => latestTxs?.reverse()),
     );
   }
 
@@ -84,9 +106,5 @@ export class TxsComponent implements OnInit {
   appPaginationChanged(pageEvent: PageEvent): void {
     this.pageSize$.next(pageEvent.pageSize);
     this.pageNumber$.next(pageEvent.pageIndex + 1);
-    this.pageLength$.next(pageEvent.length);
-    const paginatedTxHeight =
-      this.latestTxHeight$.getValue() - BigInt(pageEvent.pageIndex) * BigInt(pageEvent.pageSize);
-    this.firstTxHeight$.next(paginatedTxHeight);
   }
 }

--- a/projects/main/src/app/views/blocks/blocks.component.html
+++ b/projects/main/src/app/views/blocks/blocks.component.html
@@ -1,5 +1,5 @@
 <h2>Latest Blocks</h2>
-<div class="latest-blocks-scroll">
+<div>
   <mat-card>
     <mat-nav-list>
       <ng-container
@@ -7,13 +7,17 @@
       ></ng-container>
       <ng-template #empty></ng-template>
       <ng-template #exist>
-        <h3>Latest Blocks</h3>
+        <mat-list-item>
+          <span class="break-all truncate pr-4">Height</span>
+          <span class="flex-auto"></span>
+          <span class="break-all truncate">Hash</span>
+        </mat-list-item>
         <ng-container *ngFor="let latestBlock of latestBlocks">
           <mat-divider></mat-divider>
           <mat-list-item routerLink="/blocks/{{ latestBlock?.block?.header?.height }}">
-            <span class="column-value">{{ latestBlock?.block?.header?.height }}</span>
+            <span class="pr-4">{{ latestBlock?.block?.header?.height }}</span>
             <span class="flex-auto"></span>
-            <span class="column-value">{{ latestBlock?.block?.header?.time }}</span>
+            <span class="break-all truncate">{{ latestBlock?.block?.header?.time }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
         </ng-container>

--- a/projects/main/src/app/views/home/blocks/blocks.component.css
+++ b/projects/main/src/app/views/home/blocks/blocks.component.css
@@ -1,4 +1,0 @@
-.latest-blocks-scroll {
-  overflow: auto;
-  height: 310px;
-}

--- a/projects/main/src/app/views/home/blocks/blocks.component.html
+++ b/projects/main/src/app/views/home/blocks/blocks.component.html
@@ -1,5 +1,5 @@
 <h2>Latest Blocks</h2>
-<div class="latest-blocks-scroll">
+<div class="overflow-scroll h-80">
   <mat-card>
     <mat-nav-list>
       <!--
@@ -15,13 +15,17 @@
       <ng-container *ngIf="latestBlocks === undefined || null ; then empty; else exist"></ng-container>
       <ng-template #empty></ng-template>
       <ng-template #exist>
-        <h3>Latest Blocks</h3>
+        <mat-list-item>
+          <span class="break-all truncate pr-4">Height</span>
+          <span class="flex-auto"></span>
+          <span class="break-all truncate">Time</span>
+        </mat-list-item>
         <ng-container *ngFor="let latestBlock of latestBlocks">
           <mat-divider></mat-divider>
           <mat-list-item routerLink="/blocks/{{ latestBlock?.block?.header?.height }}">
-            <span class="column-value">{{ latestBlock?.block?.header?.height }}</span>
+            <span class="pr-4">{{ latestBlock?.block?.header?.height }}</span>
             <span class="flex-auto"></span>
-            <span class="column-value">{{ latestBlock?.block?.header?.time }}</span>
+            <span class="break-all truncate">{{ latestBlock?.block?.header?.time }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
         </ng-container>

--- a/projects/main/src/app/views/home/txs/txs.component.css
+++ b/projects/main/src/app/views/home/txs/txs.component.css
@@ -1,4 +1,0 @@
-.latest-transactions-scroll {
-  overflow: auto;
-  height: 310px;
-}

--- a/projects/main/src/app/views/home/txs/txs.component.html
+++ b/projects/main/src/app/views/home/txs/txs.component.html
@@ -7,7 +7,7 @@
     </mat-select>
   </mat-form-field>
 </div>
-<div class="latest-transactions-scroll">
+<div class="overflow-scroll h-80">
   <mat-card>
     <mat-nav-list>
       <!--
@@ -23,13 +23,17 @@
       <ng-container *ngIf="initialTxs === undefined || null ; then empty; else exist"></ng-container>
       <ng-template #empty></ng-template>
       <ng-template #exist>
-        <h3>Latest Transactions</h3>
+        <mat-list-item>
+          <span class="break-all truncate pr-4">Block Height</span>
+          <span class="flex-auto"></span>
+          <span class="break-all truncate">Tx Hash</span>
+        </mat-list-item>
         <mat-divider></mat-divider>
         <ng-container *ngFor="let initialTx of initialTxs">
           <mat-list-item routerLink="/txs/{{ initialTx.txhash }}">
-            <span class="column-value">{{ initialTx.height }}</span>
+            <span class="pr-4">{{ initialTx.height }}</span>
             <span class="flex-auto"></span>
-            <span class="column-value">{{ initialTx.txhash }}</span>
+            <span class="break-all truncate">{{ initialTx.txhash }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
         </ng-container>

--- a/projects/main/src/app/views/txs/txs.component.html
+++ b/projects/main/src/app/views/txs/txs.component.html
@@ -1,5 +1,5 @@
 <div class="flex flex-row justify-between content-start items-start">
-  <h2>Latest Transactions</h2>
+  <h2>Transactions</h2>
   <mat-form-field appearance="fill">
     <mat-select [(value)]="selectedTxType" (valueChange)="onSelectedTxTypeChanged($event)">
       <mat-option *ngFor="let txType of txTypeOptions" [value]="txType">{{txType}}
@@ -7,19 +7,23 @@
     </mat-select>
   </mat-form-field>
 </div>
-<div class="latest-transactions-scroll">
+<div>
   <mat-card>
     <mat-nav-list>
-      <ng-container *ngIf="latestTxs === undefined || null ; then empty; else exist"></ng-container>
+      <ng-container *ngIf="txs === undefined || null ; then empty; else exist"></ng-container>
       <ng-template #empty></ng-template>
       <ng-template #exist>
-        <h3>Latest Transactions</h3>
+        <mat-list-item>
+          <span class="break-all truncate pr-4">Block Height</span>
+          <span class="flex-auto"></span>
+          <span class="break-all truncate">Tx Hash</span>
+        </mat-list-item>
         <mat-divider></mat-divider>
-        <ng-container *ngFor="let latestTx of latestTxs">
-          <mat-list-item routerLink="/txs/{{ latestTx.txhash }}">
-            <span class="column-value">{{ latestTx.height }}</span>
+        <ng-container *ngFor="let tx of txs">
+          <mat-list-item routerLink="/txs/{{ tx.txhash }}">
+            <span class="pr-4">{{ tx.height }}</span>
             <span class="flex-auto"></span>
-            <span class="column-value">{{ latestTx.txhash }}</span>
+            <span class="break-all truncate">{{ tx.txhash }}</span>
           </mat-list-item>
           <mat-divider></mat-divider>
         </ng-container>

--- a/projects/main/src/app/views/txs/txs.component.ts
+++ b/projects/main/src/app/views/txs/txs.component.ts
@@ -9,7 +9,7 @@ import { CosmosTxV1beta1GetTxsEventResponseTxResponses } from 'cosmos-client/esm
 })
 export class TxsComponent implements OnInit {
   @Input()
-  latestTxs?: CosmosTxV1beta1GetTxsEventResponseTxResponses[] | null;
+  txs?: CosmosTxV1beta1GetTxsEventResponseTxResponses[] | null;
   @Input()
   txTypeOptions?: string[] | null;
   @Input()


### PR DESCRIPTION
@KimuraYu45z cc: @taro04 @Senna46 
レビューお願いします。

つのださんの作業ブランチ・プルリク( https://github.com/lcnem/telescope/pull/164 )の内容を引き継ぎ、トランザクション一覧ページに、ページネーションを実装したり、トランザクション一覧とブロック一覧の小画面でのレイアウト崩れを修正したり、生のcssをtailwind化したりしたプルリクです。

最終的には最新トランザクションが上に表示される降順でのページネーションを実装したいと思うのですが、いったん、昇順の状態で最も古いトランザクションが上に表示される昇順でのページネーションとして実装しました。

まずはこの状態で次に進みたいと思っています。(ホーム画面のコンポーネントは、最新トランザクション20件の一覧が表示されているのみでページネーションなし、/txsページのトランザクション一覧画面のコンポーネントでは昇順でページネーション実装済の状態での表示となります。)