### PR TITLE
feat: add_configjs_monitor_page

### DIFF
--- a/projects/main/src/app/views/app.component.html
+++ b/projects/main/src/app/views/app.component.html
@@ -16,7 +16,6 @@
       <mat-list-item routerLink="/cosmos/bank">Bank</mat-list-item>
       <mat-list-item routerLink="/cosmos/staking">Staking</mat-list-item>
       <mat-list-item routerLink="/cosmos/gov">Gov</mat-list-item>
-      <mat-list-item routerLink="/monitor">Monitor</mat-list-item>
       <ng-template ngFor let-extension [ngForOf]="extensionNavigations">
         <ng-container *ngIf="extension?.name && extension?.link">
           <a mat-list-item [href]="extension.link">


### PR DESCRIPTION
telescopeへのMonitorのsidenav表示を固定ではなくconfigに応じて動的に表示非表示コントロールするよう修正。
config.jsの有無でsidenavへの表示非常時を確認しました。
![20211019_monitor](https://user-images.githubusercontent.com/75844498/137907367-3c17413b-25dc-4a68-ac59-080ed8453555.png)
(faucetと順序変わってしまいましたが、問題ないでしょうか・)
