### PR TITLE
fix: gentx mismatch of val cons pub key

### DIFF
--- a/projects/main/src/app/models/cosmos/gentx.service.ts
+++ b/projects/main/src/app/models/cosmos/gentx.service.ts
@@ -5,7 +5,6 @@ import { KeyService } from '../keys/key.service';
 import { GentxData } from './gentx.model';
 import { Injectable } from '@angular/core';
 import { cosmosclient, proto } from '@cosmos-client/core';
-import * as bech32 from 'bech32';
 
 @Injectable({
   providedIn: 'root',
@@ -33,13 +32,13 @@ export class GentxService {
     }
 
     console.log('gentxData.pubkey', gentxData.pubkey);
-    const publicKeyNumberArray = bech32.decode(gentxData.pubkey).words;
-    console.log('publicKeyNumberArray', publicKeyNumberArray);
+    const base64DecodedPublicKey = Uint8Array.from(Buffer.from(gentxData.pubkey, 'base64'));
+    console.log('base64DecodedPublicKey', base64DecodedPublicKey);
     const publicKey = new proto.cosmos.crypto.ed25519.PubKey({
-      key: new Uint8Array(bech32.fromWords(publicKeyNumberArray)),
+      key: base64DecodedPublicKey,
     });
-    const packCosmosPublicKey = cosmosclient.codec.packAny(publicKey);
-    console.log('packCosmosPublicKey', packCosmosPublicKey);
+    const packAnyPublicKey = cosmosclient.codec.packAny(publicKey);
+    console.log('packAnyPublicKey', packAnyPublicKey);
 
     // build tx
     const createValidatorTxData = {
@@ -58,7 +57,7 @@ export class GentxService {
       min_self_delegation: gentxData.min_self_delegation,
       delegator_address: gentxData.delegator_address,
       validator_address: gentxData.validator_address,
-      pubkey: packCosmosPublicKey,
+      pubkey: packAnyPublicKey,
       value: {
         denom: gentxData.denom,
         amount: gentxData.amount,


### PR DESCRIPTION
@KimuraYu45z cc: @Senna46 @taro04 
gentxの残課題のうち、木村さんから頂いたアドバイスで、validator consensus pubkeyの値が一致していなかった問題が解決できたと思うので、レビューお願いします。(型の問題は未解決ですがpubkeyの問題はこれで解決できたと思うので、先にマージしておきたいと思っています。)

ノード上の`~/.jpyx/config/priv_validator_key.json`の中の、`pub_key.value`←値は`"oYCrJpP1vlhMCh3K24FfWA5KE+KXrjkEfZENJOfVi64="`を使用し、
telescope内で、base64 decodeしてUint8Arrayにする形で修正し、以下URLでtelescopeでのgentxを再度試みたところ、問題の公開鍵が一致しました。(文字列に+や=が含まれていると正確にURL Encodeされた値をクエリパラメーターで指定しないと微妙に変わってしまいNGとなることをNeukindに明確に伝えてあげる必要がありそうと思っています。)

http://localhost:4200/keys/gentx?moniker=lcnem-test-a&rate=0.100000000000000000&max_rate=0.200000000000000000&max_change_rate=0.010000000000000000&min_self_delegation=1&delegator_address=jpyx10lcj22kzftvnduchatmnsnhfljeky5ghd398wt&validator_address=jpyxvaloper10lcj22kzftvnduchatmnsnhfljeky5ghh3zpgf&denom=ujcbn&amount=250000000000&ip=a.test.jpyx.lcnem.net&node_id=6fc4109698025d8ee20c09a78fd6b7fb858c26e2&pubkey=oYCrJpP1vlhMCh3K24FfWA5KE%2BKXrjkEfZENJOfVi64w%3D

cliで実行した際のgentx(期待値)

```json
{
	"body": {
		"messages": [
			{
				"@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
				"description": {
					"moniker": "lcnem-test-a",
					"identity": "",
					"website": "",
					"security_contact": "",
					"details": ""
				},
				"commission": {
					"rate": "0.100000000000000000",
					"max_rate": "0.200000000000000000",
					"max_change_rate": "0.010000000000000000"
				},
				"min_self_delegation": "1",
				"delegator_address": "jpyx10lcj22kzftvnduchatmnsnhfljeky5ghd398wt",
				"validator_address": "jpyxvaloper10lcj22kzftvnduchatmnsnhfljeky5ghh3zpgf",
				"pubkey": {
					"@type": "/cosmos.crypto.ed25519.PubKey",
					"key": "oYCrJpP1vlhMCh3K24FfWA5KE+KXrjkEfZENJOfVi64="
				},
				"value": {
					"denom": "ujcbn",
					"amount": "250000000000"
				}
			}
		],
		"memo": "6fc4109698025d8ee20c09a78fd6b7fb858c26e2@a.test.jpyx.lcnem.net:26656",
		"timeout_height": "0",
		"extension_options": [],
		"non_critical_extension_options": []
	},
	"auth_info": {
		"signer_infos": [
			{
				"public_key": {
					"@type": "/cosmos.crypto.secp256k1.PubKey",
					"key": "AvSf2U/B23UZKvLTD0E4xqJ33Nn0Z552nXCkkwEfleiu"
				},
				"mode_info": {
					"single": {
						"mode": "SIGN_MODE_DIRECT"
					}
				},
				"sequence": "0"
			}
		],
		"fee": {
			"amount": [],
			"gas_limit": "200000",
			"payer": "",
			"granter": ""
		}
	},
	"signatures": [
		"nPXOvjdj07cGTKfVvmMd5ezxdCzsK9aBHS+YF1iQhzgDGqF2Uly1xzTaphkJljbvboigrcLLpjHeNGrN49Nl0g=="
	]
}
```

telescopeで実行した際のgentx

```json
{
	"body": {
		"messages": [
			{
				"@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
				"description": {
					"moniker": "lcnem-test-a",
					"identity": "",
					"website": "",
					"security_contact": "",
					"details": ""
				},
				"commission": {
					"rate": "0.100000000000000000",
					"max_rate": "0.200000000000000000",
					"max_change_rate": "0.010000000000000000"
				},
				"min_self_delegation": "1",
				"delegator_address": "jpyx10lcj22kzftvnduchatmnsnhfljeky5ghd398wt",
				"validator_address": "jpyxvaloper10lcj22kzftvnduchatmnsnhfljeky5ghh3zpgf",
				"pubkey": {
					"@type": "/cosmos.crypto.ed25519.PubKey",
					"key": "oYCrJpP1vlhMCh3K24FfWA5KE+KXrjkEfZENJOfVi64w"
				},
				"value": {
					"denom": "ujcbn",
					"amount": "250000000000"
				}
			}
		],
		"extension_options": [],
		"non_critical_extension_options": [],
		"memo": "6fc4109698025d8ee20c09a78fd6b7fb858c26e2@a.test.jpyx.lcnem.net:26656",
		"timeout_height": 0
	},
	"auth_info": {
		"signer_infos": [
			{
				"public_key": {
					"@type": "/cosmos.crypto.secp256k1.PubKey",
					"key": "AvSf2U/B23UZKvLTD0E4xqJ33Nn0Z552nXCkkwEfleiu"
				},
				"mode_info": {
					"single": {
						"mode": 1
					},
					"multi": {}
				},
				"sequence": 0
			}
		],
		"fee": {
			"amount": [],
			"gas_limit": 200000,
			"payer": "",
			"granter": ""
		}
	},
	"signatures": [
		"VDN3KEoqNr4QXd9JfIowNwohK8UkPRrAmz39vpgR0i91oMuO+l3ciVA+QY4y7PugchtZJI+R9Oc1jVCOc3NHwQ=="
	]
}
```
